### PR TITLE
chore: remove maxDuration

### DIFF
--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -2,8 +2,6 @@ import { serve } from "inngest/next";
 import { inngest } from "@/inngest/client";
 import { processFunction } from "@inngest/functions/process";
 
-export const maxDuration = 900;
-
 export const { GET, POST, PUT } = serve({
     client: inngest,
     functions: [processFunction],


### PR DESCRIPTION
We're planning to switch on fluid compute by default. maxDuration must be removed from all apps.

It is no longer necessary and will default to maximum allowed (800s).

