### PR TITLE
Readme: include document URLs and API definition if there is an endpoint

### DIFF
--- a/src/inngest/client.ts
+++ b/src/inngest/client.ts
@@ -2,8 +2,8 @@ import { EventSchemas, Inngest } from "inngest";
 import { z } from "zod";
 
 // TODO: Should we set this in an env variable or compute it from the appId?
-const INNGEST_ID = "app/readme-develop";
-// const INNGEST_ID = "app/readme";
+// const INNGEST_ID = "app/readme-develop";
+const INNGEST_ID = "app/readme";
 
 export const inngest = new Inngest({
     id: INNGEST_ID,

--- a/src/inngest/client.ts
+++ b/src/inngest/client.ts
@@ -1,10 +1,14 @@
 import { EventSchemas, Inngest } from "inngest";
 import { z } from "zod";
 
+// TODO: Should we set this in an env variable or compute it from the appId?
+const INNGEST_ID = "app/readme-develop";
+// const INNGEST_ID = "app/readme";
+
 export const inngest = new Inngest({
-    id: "app/readme-develop",
+    id: INNGEST_ID,
     schemas: new EventSchemas().fromZod({
-        "app/readme-develop/process": {
+        [`${INNGEST_ID}/process`]: {
             data: z.object({
                 organizationId: z.string(),
                 agentId: z.string(),

--- a/src/inngest/functions/process.ts
+++ b/src/inngest/functions/process.ts
@@ -18,14 +18,14 @@ export const processFunction = inngest.createFunction(
     },
     async ({ event, step }) => {
         const { organizationId, agentId, settings, knowledgeBaseId } = event.data;
-        const platform = new MavenAGIClient({ organizationId, agentId });
+        const mavenClient = new MavenAGIClient({ organizationId, agentId });
         const baseProjectUrl = await getProjectBaseUrl(settings.token);
 
         // Just in case we had a past failure, finalize any old versions so we can start from scratch
         // TODO(maven): Make the platform more lenient so this isn't necessary
         await step.run('finalize-knowledge-base-version', async () => {
             try {
-                await platform.knowledge.finalizeKnowledgeBaseVersion(knowledgeBaseId);
+                await mavenClient.knowledge.finalizeKnowledgeBaseVersion(knowledgeBaseId);
             } catch (error) {
                 // Ignored
             }
@@ -33,7 +33,7 @@ export const processFunction = inngest.createFunction(
 
         // Make a new kb version
         await step.run('create-knowledge-base-version', async () => {
-            await platform.knowledge.createKnowledgeBaseVersion(knowledgeBaseId, {
+            await mavenClient.knowledge.createKnowledgeBaseVersion(knowledgeBaseId, {
                 type: 'FULL',
             });
         })
@@ -69,7 +69,7 @@ export const processFunction = inngest.createFunction(
             for (const category of categories) {
                 await step.run('process-documents', async () => {
                     const { slug }: any = category;
-                    await processDocsForCategory(platform, settings.token, baseProjectUrl, slug, knowledgeBaseId);
+                    await processDocsForCategory(settings.token, baseProjectUrl, slug, mavenClient, knowledgeBaseId);
                 })
             }
         }
@@ -77,7 +77,7 @@ export const processFunction = inngest.createFunction(
         // Finalize the version
         await step.run('finalize-knowledge-base-version-final', async () => {
             console.log('Finished processing all articles');
-            await platform.knowledge.finalizeKnowledgeBaseVersion(knowledgeBaseId);
+            await mavenClient.knowledge.finalizeKnowledgeBaseVersion(knowledgeBaseId);
         })
     }
 );

--- a/src/inngest/functions/process.ts
+++ b/src/inngest/functions/process.ts
@@ -1,6 +1,6 @@
 import {inngest} from "@inngest/client";
 import {MavenAGIClient} from 'mavenagi';
-import {callReadmeApi, processDocsForCategory} from "@inngest/readme"
+import {getProjectBaseUrl, callReadmeApi, processDocsForCategory} from "@inngest/readme"
 import {INNGEST_EVENT} from "@inngest/constants";
 
 export const processFunction = inngest.createFunction(
@@ -19,6 +19,7 @@ export const processFunction = inngest.createFunction(
     async ({ event, step }) => {
         const { organizationId, agentId, settings, knowledgeBaseId } = event.data;
         const platform = new MavenAGIClient({ organizationId, agentId });
+        const baseProjectUrl = await getProjectBaseUrl(settings.token);
 
         // Just in case we had a past failure, finalize any old versions so we can start from scratch
         // TODO(maven): Make the platform more lenient so this isn't necessary
@@ -68,7 +69,7 @@ export const processFunction = inngest.createFunction(
             for (const category of categories) {
                 await step.run('process-documents', async () => {
                     const { slug }: any = category;
-                    await processDocsForCategory(platform, settings.token, slug, knowledgeBaseId);
+                    await processDocsForCategory(platform, settings.token, baseProjectUrl, slug, knowledgeBaseId);
                 })
             }
         }

--- a/src/inngest/readme.ts
+++ b/src/inngest/readme.ts
@@ -24,9 +24,21 @@ export async function callReadmeApi(path: string, token: string) {
     return response.json();
 }
 
+export async function getProjectBaseUrl(token: string) {
+    // No path returns the metadata for the specified project token
+    const metadata = await callReadmeApi('', token);
+    return metadata.baseUrl;
+}
+
+function getDocUrlForSlug(baseUrl: string, slug: string) {
+    // The slug is the path to the document
+    return `${baseUrl}/docs/${slug}`;
+}
+
 export async function processDocsForCategory(
     mavenAgi: MavenAGIClient,
     token: string,
+    baseDocUrl: string,
     categoryId: string,
     knowledgeBaseId: string
 ) {
@@ -34,28 +46,30 @@ export async function processDocsForCategory(
     console.log('Processing documents in category:', categoryId);
 
     for (const document of docs) {
-        await processDocumentWithChildren(document, token, mavenAgi, knowledgeBaseId);
+        await processDocumentWithChildren(document, token, baseDocUrl, mavenAgi, knowledgeBaseId);
     }
 }
 
 export async function processDocumentWithChildren(
     document: any,
     token: string,
+    baseDocUrl: string,
     mavenAgi: MavenAGIClient,
     knowledgeBaseId: string
 ) {
     // Process main document
-    await processDoc(document, token, mavenAgi, knowledgeBaseId);
+    await processDoc(document, token, baseDocUrl, mavenAgi, knowledgeBaseId);
 
     // Process child documents
     for (const childDocument of document.children) {
-        await processDoc(childDocument, token, mavenAgi, knowledgeBaseId);
+        await processDoc(childDocument, token, baseDocUrl, mavenAgi, knowledgeBaseId);
     }
 }
 
 export async function processDoc(
     doc: any,
     token: string,
+    baseDocUrl: string,
     mavenAgi: MavenAGIClient,
     knowledgeBaseId: string
 ) {
@@ -67,6 +81,7 @@ export async function processDoc(
             title: fullReadmeDoc.title,
             content: fullReadmeDoc.body,
             contentType: 'MARKDOWN',
+            url: getDocUrlForSlug(baseDocUrl, doc.slug),
             knowledgeDocumentId: { referenceId: doc.slug },
         });
     }

--- a/src/inngest/readme.ts
+++ b/src/inngest/readme.ts
@@ -1,5 +1,6 @@
 import {MavenAGIClient} from "mavenagi";
 import {README_API_BASE_URL} from "@inngest/constants";
+import * as APITypes from "@inngest/readmeApi"
 
 
 export async function callReadmeApi(path: string, token: string) {
@@ -19,8 +20,6 @@ export async function callReadmeApi(path: string, token: string) {
         );
     }
 
-    console.log('Successful Readme API call for ' + endpoint);
-    console.log('Response:', response);
     return response.json();
 }
 
@@ -35,11 +34,47 @@ function getDocUrlForSlug(baseUrl: string, slug: string) {
     return `${baseUrl}/docs/${slug}`;
 }
 
+function getMarkdownForEndpoint(url: string, method: string) {
+    return `**Endpoint**: ${url}\n**Method**: ${method}`;
+}
+
+function getMarkdownForPathParameters(params: APITypes.APIParameter[]) {
+    return params.map((p) => {
+        return `**${p.name}** ${p.type} ${p.required ? "required" : "optional"}\n${p.desc}`;
+    }).join('\n\n');  
+
+}
+
+function getMarkdownForBodyPayloads(params: APITypes.APIParameter[]) {
+    return params.map((p) => {
+        return `**${p.name}** ${p.type}\n${p.desc}`;
+    }).join('\n\n');
+
+}
+
+function getMarkdownForResponses(responses: APITypes.APIResults) {
+    return responses?.codes?.sort((a, b) => a.status - b.status).map((r) => {    
+        return `**${r.status}**\n${r.language}\n\`\`\`${r.code}\`\`\``;
+    }).join('\n\n');
+}
+
+function convertAPIToMarkdown(api: APITypes.APIDefinition) {
+    if (!api || !api.url) {
+        return "";
+    }    
+    const endpoint = getMarkdownForEndpoint(api.url, api.method);
+    const params = getMarkdownForPathParameters(api.params.filter((param) => param.in === 'path'));
+    const payloads = getMarkdownForBodyPayloads(api.params.filter((param) => param.in === 'body'));
+    const responses = getMarkdownForResponses(api.results);
+
+    return `${endpoint}\n\n**PATH PARAMS**\n\n${params}\n\n**BODY PARAMS**\n\n${payloads}\n\n**RESPONSES**\n\n${responses}`;
+}
+
 export async function processDocsForCategory(
-    mavenAgi: MavenAGIClient,
     token: string,
     baseDocUrl: string,
     categoryId: string,
+    mavenAgi: MavenAGIClient,
     knowledgeBaseId: string
 ) {
     const docs = await callReadmeApi(`/categories/${categoryId}/docs`, token);
@@ -78,8 +113,9 @@ export async function processDoc(
     if (fullReadmeDoc.body) {
         console.log('Creating knowledge document for:', fullReadmeDoc.title);
         const body = fullReadmeDoc.body || "";
-        const api = fullReadmeDoc.api || {};
-        const content = `${body}${api ? `\n\n${JSON.stringify(api)}`: ""}`;
+        const apiDoc = convertAPIToMarkdown(fullReadmeDoc.api);
+        const content = `${body}${apiDoc ? `\n\n${apiDoc}`: ""}`;
+
         await mavenAgi.knowledge.createKnowledgeDocument(knowledgeBaseId, {
             title: fullReadmeDoc.title,
             content: content,

--- a/src/inngest/readme.ts
+++ b/src/inngest/readme.ts
@@ -77,9 +77,12 @@ export async function processDoc(
     const fullReadmeDoc = await callReadmeApi(`/docs/${doc.slug}`, token);
     if (fullReadmeDoc.body) {
         console.log('Creating knowledge document for:', fullReadmeDoc.title);
+        const body = fullReadmeDoc.body || "";
+        const api = fullReadmeDoc.api || {};
+        const content = `${body}${api ? `\n\n${JSON.stringify(api)}`: ""}`;
         await mavenAgi.knowledge.createKnowledgeDocument(knowledgeBaseId, {
             title: fullReadmeDoc.title,
-            content: fullReadmeDoc.body,
+            content: content,
             contentType: 'MARKDOWN',
             url: getDocUrlForSlug(baseDocUrl, doc.slug),
             knowledgeDocumentId: { referenceId: doc.slug },

--- a/src/inngest/readmeApi.d.ts
+++ b/src/inngest/readmeApi.d.ts
@@ -1,0 +1,38 @@
+export type HTTPMethod = 'get' | 'post' | 'put' | 'delete' | 'patch';
+
+export interface APIResponseCode {
+  name: string;
+  code: string;
+  language: string;
+  status: number;
+}
+
+export interface APIParameter {
+  name: string;
+  type: string;
+  enumValues: string;
+  default: string;
+  desc: string;
+  required: boolean;
+  in: 'path' | 'body';
+  ref: string;
+  _id: string;
+}
+
+export interface APIResults {
+  codes: APIResponseCode[];
+}
+
+export interface APIExamples {
+  codes: unknown[];
+}
+
+export interface APIDefinition {
+  method: HTTPMethod;
+  url: string;
+  auth: 'required' | 'optional';
+  results: APIResults;
+  params: APIParameter[];
+  examples: APIExamples;
+  apiSetting: string;
+}


### PR DESCRIPTION
To complete the Ingestion of CheckHQ's doc:

1. Add the URL to the original Readme doc to each Maven doc
2. Include the API definition as Markdown for every document with an endpoint. 