### PR TITLE
More CheckHQ fixes

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,15 @@
+{
+  "semi": true,
+  "trailingComma": "es5",
+  "singleQuote": true,
+  "tabWidth": 2,
+  "useTabs": false,
+  "printWidth": 100,
+  "jsxSingleQuote": false,
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf",
+  "importOrder": ["^@core/(.*)$", "^@server/(.*)$", "^@ui/(.*)$", "^[./]"],
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "next": "14.2.5",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "bottleneck": "^2.19.5"
   },
   "scripts": {
     "build": "next build"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@vercel/functions':
         specifier: 1.4.0
         version: 1.4.0
+      bottleneck:
+        specifier: ^2.19.5
+        version: 2.19.5
       inngest:
         specifier: ^3.31.13
         version: 3.32.2(next@14.2.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
@@ -170,6 +173,9 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bottleneck@2.19.5:
+    resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
@@ -658,6 +664,8 @@ snapshots:
   asynckit@0.4.0: {}
 
   base64-js@1.5.1: {}
+
+  bottleneck@2.19.5: {}
 
   buffer@6.0.3:
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-import {MavenAGIClient, MavenAGI} from 'mavenagi';
-import {inngest} from "@inngest/client";
-import {callReadmeApi} from "@inngest/readme";
-import {INNGEST_EVENT, KNOWLEDGE_BASE_ID} from "@inngest/constants";
+import { MavenAGIClient, MavenAGI } from 'mavenagi';
+import { inngest } from '@inngest/client';
+import { callReadmeApi } from '@inngest/readme';
+import { INNGEST_EVENT, KNOWLEDGE_BASE_ID } from '@inngest/constants';
 
 export default {
   async preInstall({ settings }) {
@@ -17,7 +17,6 @@ export default {
       agentId,
     });
 
-    // Make one maven knowledge base for readme-develop
     await mavenAgi.knowledge.createOrUpdateKnowledgeBase({
       name: 'ReadMe',
       type: MavenAGI.KnowledgeBaseType.Api,
@@ -30,17 +29,12 @@ export default {
         organizationId,
         agentId,
         settings,
-        knowledgeBaseId: KNOWLEDGE_BASE_ID
-      }
-    })
+        knowledgeBaseId: KNOWLEDGE_BASE_ID,
+      },
+    });
   },
 
-  async knowledgeBaseRefreshed({
-    organizationId,
-    agentId,
-    knowledgeBaseId,
-    settings,
-  }) {
+  async knowledgeBaseRefreshed({ organizationId, agentId, knowledgeBaseId, settings }) {
     console.log('Refresh request for ' + knowledgeBaseId.referenceId);
 
     // If we get a refresh request, create a new version for the knowledge base and add documents
@@ -50,8 +44,8 @@ export default {
         organizationId,
         agentId,
         settings,
-        knowledgeBaseId: KNOWLEDGE_BASE_ID
-      }
-    })
+        knowledgeBaseId: KNOWLEDGE_BASE_ID,
+      },
+    });
   },
 };

--- a/src/inngest/client.ts
+++ b/src/inngest/client.ts
@@ -2,8 +2,8 @@ import { EventSchemas, Inngest } from "inngest";
 import { z } from "zod";
 
 // TODO: Should we set this in an env variable or compute it from the appId?
-// const INNGEST_ID = "app/readme-develop";
-const INNGEST_ID = "app/readme";
+const INNGEST_ID = "app/readme-develop";
+// const INNGEST_ID = "app/readme";
 
 export const inngest = new Inngest({
     id: INNGEST_ID,

--- a/src/inngest/client.ts
+++ b/src/inngest/client.ts
@@ -1,22 +1,22 @@
-import { EventSchemas, Inngest } from "inngest";
-import { z } from "zod";
+import { EventSchemas, Inngest } from 'inngest';
+import { z } from 'zod';
 
 // TODO: Should we set this in an env variable or compute it from the appId?
-const INNGEST_ID = "app/readme-develop";
-// const INNGEST_ID = "app/readme";
+// const INNGEST_ID = "app/readme-develop";
+const INNGEST_ID = 'app/readme';
 
 export const inngest = new Inngest({
-    id: INNGEST_ID,
-    schemas: new EventSchemas().fromZod({
-        [`${INNGEST_ID}/process`]: {
-            data: z.object({
-                organizationId: z.string(),
-                agentId: z.string(),
-                settings: z.object({
-                    token: z.string()
-                }),
-                knowledgeBaseId: z.string()
-            }),
-        },
-    }),
+  id: INNGEST_ID,
+  schemas: new EventSchemas().fromZod({
+    [`${INNGEST_ID}/process`]: {
+      data: z.object({
+        organizationId: z.string(),
+        agentId: z.string(),
+        settings: z.object({
+          token: z.string(),
+        }),
+        knowledgeBaseId: z.string(),
+      }),
+    },
+  }),
 });

--- a/src/inngest/constants.ts
+++ b/src/inngest/constants.ts
@@ -2,4 +2,4 @@ export const INNGEST_EVENT = 'app/readme-develop/process';
 
 export const README_API_BASE_URL = 'https://dash.readme.com/api/v1';
 
-export const KNOWLEDGE_BASE_ID = 'readme';
+export const KNOWLEDGE_BASE_ID = 'readme-develop';

--- a/src/inngest/constants.ts
+++ b/src/inngest/constants.ts
@@ -1,5 +1,5 @@
-export const INNGEST_EVENT = 'app/readme-develop/process';
+export const INNGEST_EVENT = 'app/readme/process';
 
 export const README_API_BASE_URL = 'https://dash.readme.com/api/v1';
 
-export const KNOWLEDGE_BASE_ID = 'readme-develop';
+export const KNOWLEDGE_BASE_ID = 'readme';

--- a/src/inngest/constants.ts
+++ b/src/inngest/constants.ts
@@ -1,4 +1,4 @@
-export const INNGEST_EVENT = 'app/readme/process';
+export const INNGEST_EVENT = 'app/readme-develop/process';
 
 export const README_API_BASE_URL = 'https://dash.readme.com/api/v1';
 

--- a/src/inngest/functions/process.ts
+++ b/src/inngest/functions/process.ts
@@ -1,83 +1,84 @@
-import {inngest} from "@inngest/client";
-import {MavenAGIClient} from 'mavenagi';
-import {getProjectBaseUrl, callReadmeApi, processDocsForCategory} from "@inngest/readme"
-import {INNGEST_EVENT} from "@inngest/constants";
+import { inngest } from '@inngest/client';
+import { MavenAGIClient } from 'mavenagi';
+import { getProjectBaseUrl, callReadmeApi, processDocsForCategory } from '@inngest/readme';
+import { INNGEST_EVENT } from '@inngest/constants';
 
 export const processFunction = inngest.createFunction(
-    {
-        id: "process",
-    },
-    {
-        event: INNGEST_EVENT,
-        concurrency: [
-            {
-                key: "event.data.agentId",
-                limit: 50
-            }
-        ],
-    },
-    async ({ event, step }) => {
-        const { organizationId, agentId, settings, knowledgeBaseId } = event.data;
-        const mavenClient = new MavenAGIClient({ organizationId, agentId });
-        const baseProjectUrl = await getProjectBaseUrl(settings.token);
+  {
+    id: 'process',
+  },
+  {
+    event: INNGEST_EVENT,
+    concurrency: [
+      {
+        key: 'event.data.agentId',
+        limit: 50,
+      },
+    ],
+  },
+  async ({ event, step }) => {
+    const { organizationId, agentId, settings, knowledgeBaseId } = event.data;
+    const mavenClient = new MavenAGIClient({ organizationId, agentId });
+    const baseProjectUrl = await getProjectBaseUrl(settings.token);
 
-        // Just in case we had a past failure, finalize any old versions so we can start from scratch
-        // TODO(maven): Make the platform more lenient so this isn't necessary
-        await step.run('finalize-knowledge-base-version', async () => {
-            try {
-                await mavenClient.knowledge.finalizeKnowledgeBaseVersion(knowledgeBaseId);
-            } catch (error) {
-                // Ignored
-            }
+    // Just in case we had a past failure, finalize any old versions so we can start from scratch
+    // TODO(maven): Make the platform more lenient so this isn't necessary
+    await step.run('finalize-knowledge-base-version', async () => {
+      try {
+        await mavenClient.knowledge.finalizeKnowledgeBaseVersion(knowledgeBaseId);
+      } catch (error) {
+        // Ignored
+      }
+    });
+
+    // Make a new kb version
+    await step.run('create-knowledge-base-version', async () => {
+      await mavenClient.knowledge.createKnowledgeBaseVersion(knowledgeBaseId, {
+        type: 'FULL',
+      });
+    });
+
+    // Fetch and save all readme articles to the kb
+    // Readme only allows fetching docs from within a category so we loop over each one
+    const categories = await step.run('process-categories', async () => {
+      let page = 1;
+      let hasMorePages = true;
+      let fetchedCategories = [];
+
+      while (hasMorePages) {
+        console.log('Fetching categories page', page);
+        const res: [] = await callReadmeApi(`/categories?perPage=100&page=${page}`, settings.token);
+        fetchedCategories.push(...res);
+        console.log('Categories: ', fetchedCategories);
+        hasMorePages = res.length > 0;
+        page++;
+      }
+      console.log('Processed categories: ', fetchedCategories);
+      return fetchedCategories;
+    });
+
+    // Process each category
+    if (categories.length === 0) {
+      throw new Error('No categories found');
+    } else {
+      for (const category of categories) {
+        await step.run('process-documents', async () => {
+          const { slug }: any = category;
+          await processDocsForCategory(
+            settings.token,
+            baseProjectUrl,
+            slug,
+            mavenClient,
+            knowledgeBaseId
+          );
         });
-
-        // Make a new kb version
-        await step.run('create-knowledge-base-version', async () => {
-            await mavenClient.knowledge.createKnowledgeBaseVersion(knowledgeBaseId, {
-                type: 'FULL',
-            });
-        })
-
-        // Fetch and save all readme articles to the kb
-        // Readme only allows fetching docs from within a category so we loop over each one
-        const categories = await step.run('process-categories', async () => {
-            let page = 1;
-            let hasMorePages = true;
-            let fetchedCategories = [];
-
-            while (hasMorePages) {
-                console.log('Fetching categories page', page);
-                const res: [] = await callReadmeApi(
-                    `/categories?perPage=100&page=${page}`,
-                    settings.token
-                );
-                fetchedCategories.push(...res);
-                console.log('Categories: ', fetchedCategories);
-                hasMorePages = res.length > 0;
-                page++;
-            }
-            console.log('Processed categories: ', fetchedCategories);
-            return fetchedCategories;
-        })
-
-
-        // Process documents
-        console.log('Processing documents', categories);
-        if (categories.length === 0) {
-            throw new Error('No categories found');
-        } else {
-            for (const category of categories) {
-                await step.run('process-documents', async () => {
-                    const { slug }: any = category;
-                    await processDocsForCategory(settings.token, baseProjectUrl, slug, mavenClient, knowledgeBaseId);
-                })
-            }
-        }
-
-        // Finalize the version
-        await step.run('finalize-knowledge-base-version-final', async () => {
-            console.log('Finished processing all articles');
-            await mavenClient.knowledge.finalizeKnowledgeBaseVersion(knowledgeBaseId);
-        })
+      }
     }
+
+    // Finalize the version
+    await step.run('finalize-knowledge-base-version-final', async () => {
+      console.log('Finished processing all articles');
+      await mavenClient.knowledge.finalizeKnowledgeBaseVersion(knowledgeBaseId);
+    });
+  }
 );

--- a/src/inngest/functions/process.ts
+++ b/src/inngest/functions/process.ts
@@ -9,7 +9,7 @@ import {
 import { INNGEST_EVENT } from '@inngest/constants';
 
 // How many documents per Inngest step
-const README_PAGE_SIZE = 25;
+const README_PAGE_SIZE = 15;
 
 export const processFunction = inngest.createFunction(
   {
@@ -66,14 +66,16 @@ export const processFunction = inngest.createFunction(
 
     // Process each category
     if (categories.length === 0) {
-      throw new Error('No categories found');
+      console.log('No categories found');
     } else {
       for (const category of categories) {
         const { slug }: any = category;
-        const docs = await getDocsForCategory(settings.token, slug);
+        const docs = await step.run(`fetch-category-docs-${slug}`, async () => {
+          return await getDocsForCategory(settings.token, slug);
+        });
         for (let i = 0; i < docs.length; i += README_PAGE_SIZE) {
           const start = i,
-            end = i + README_PAGE_SIZE;
+            end = i + Math.min(docs.length, README_PAGE_SIZE);
           await step.run(`process-documents-${slug}-${start}-${end}`, async () => {
             const page = docs.slice(start, end);
             for (const doc of page) {

--- a/src/inngest/functions/process.ts
+++ b/src/inngest/functions/process.ts
@@ -9,8 +9,6 @@ import {
 } from '@inngest/readme';
 import { INNGEST_EVENT } from '@inngest/constants';
 
-// How many documents per Inngest step
-const README_PAGE_SIZE = 15;
 const BOTTLENECK_MAX_CONCURRENT = 16;
 const BOTTLENECK_MIN_TIME = 5;
 

--- a/src/inngest/functions/process.ts
+++ b/src/inngest/functions/process.ts
@@ -73,22 +73,18 @@ export const processFunction = inngest.createFunction(
         const docs = await step.run(`fetch-category-docs-${slug}`, async () => {
           return await getDocsForCategory(settings.token, slug);
         });
-        for (let i = 0; i < docs.length; i += README_PAGE_SIZE) {
-          const start = i,
-            end = i + Math.min(docs.length, README_PAGE_SIZE);
-          await step.run(`process-documents-${slug}-${start}-${end}`, async () => {
-            const page = docs.slice(start, end);
-            for (const doc of page) {
-              await processDocumentWithChildren(
-                doc,
-                settings.token,
-                baseProjectUrl,
-                mavenClient,
-                knowledgeBaseId
-              );
-            }
-          });
-        }
+
+        await step.run(`process-documents-${slug}-0-${docs.length}`, async () => {
+          for (const doc of docs) {
+            await processDocumentWithChildren(
+              doc,
+              settings.token,
+              baseProjectUrl,
+              mavenClient,
+              knowledgeBaseId
+            );
+          }
+        });
       }
     }
 

--- a/src/inngest/functions/process.ts
+++ b/src/inngest/functions/process.ts
@@ -1,7 +1,15 @@
 import { inngest } from '@inngest/client';
 import { MavenAGIClient } from 'mavenagi';
-import { getProjectBaseUrl, callReadmeApi, processDocsForCategory } from '@inngest/readme';
+import {
+  getProjectBaseUrl,
+  callReadmeApi,
+  getDocsForCategory,
+  processDocumentWithChildren,
+} from '@inngest/readme';
 import { INNGEST_EVENT } from '@inngest/constants';
+
+// How many documents per Inngest step
+const README_PAGE_SIZE = 50;
 
 export const processFunction = inngest.createFunction(
   {
@@ -53,7 +61,6 @@ export const processFunction = inngest.createFunction(
         hasMorePages = res.length > 0;
         page++;
       }
-      console.log('Processed categories: ', fetchedCategories);
       return fetchedCategories;
     });
 
@@ -62,16 +69,24 @@ export const processFunction = inngest.createFunction(
       throw new Error('No categories found');
     } else {
       for (const category of categories) {
-        await step.run('process-documents', async () => {
-          const { slug }: any = category;
-          await processDocsForCategory(
-            settings.token,
-            baseProjectUrl,
-            slug,
-            mavenClient,
-            knowledgeBaseId
-          );
-        });
+        const { slug }: any = category;
+        const docs = await getDocsForCategory(settings.token, slug);
+        for (let i = 0; i < docs.length; i += README_PAGE_SIZE) {
+          const start = i,
+            end = i + README_PAGE_SIZE;
+          await step.run(`process-documents-${slug}-${start}-${end}`, async () => {
+            const page = docs.slice(start, end);
+            for (const doc of page) {
+              await processDocumentWithChildren(
+                doc,
+                settings.token,
+                baseProjectUrl,
+                mavenClient,
+                knowledgeBaseId
+              );
+            }
+          });
+        }
       }
     }
 

--- a/src/inngest/functions/process.ts
+++ b/src/inngest/functions/process.ts
@@ -9,7 +9,7 @@ import {
 import { INNGEST_EVENT } from '@inngest/constants';
 
 // How many documents per Inngest step
-const README_PAGE_SIZE = 50;
+const README_PAGE_SIZE = 25;
 
 export const processFunction = inngest.createFunction(
   {

--- a/src/inngest/functions/process.ts
+++ b/src/inngest/functions/process.ts
@@ -5,7 +5,7 @@ import {
   getProjectBaseUrl,
   callReadmeApi,
   getDocsForCategory,
-  processDocumentWithChildren,
+  processDocument,
 } from '@inngest/readme';
 import { INNGEST_EVENT } from '@inngest/constants';
 
@@ -84,7 +84,7 @@ export const processFunction = inngest.createFunction(
             docs.map((doc) => {
               return limiter.schedule(
                 async () =>
-                  await processDocumentWithChildren(
+                  await processDocument(
                     doc,
                     settings.token,
                     baseProjectUrl,

--- a/src/inngest/functions/process.ts
+++ b/src/inngest/functions/process.ts
@@ -1,4 +1,5 @@
 import { inngest } from '@inngest/client';
+import Bottleneck from 'bottleneck';
 import { MavenAGIClient } from 'mavenagi';
 import {
   getProjectBaseUrl,
@@ -10,6 +11,8 @@ import { INNGEST_EVENT } from '@inngest/constants';
 
 // How many documents per Inngest step
 const README_PAGE_SIZE = 15;
+const BOTTLENECK_MAX_CONCURRENT = 16;
+const BOTTLENECK_MIN_TIME = 5;
 
 export const processFunction = inngest.createFunction(
   {
@@ -68,6 +71,10 @@ export const processFunction = inngest.createFunction(
     if (categories.length === 0) {
       console.log('No categories found');
     } else {
+      const limiter = new Bottleneck({
+        maxConcurrent: BOTTLENECK_MAX_CONCURRENT,
+        minTime: BOTTLENECK_MIN_TIME,
+      });
       for (const category of categories) {
         const { slug }: any = category;
         const docs = await step.run(`fetch-category-docs-${slug}`, async () => {
@@ -75,15 +82,20 @@ export const processFunction = inngest.createFunction(
         });
 
         await step.run(`process-documents-${slug}-0-${docs.length}`, async () => {
-          for (const doc of docs) {
-            await processDocumentWithChildren(
-              doc,
-              settings.token,
-              baseProjectUrl,
-              mavenClient,
-              knowledgeBaseId
-            );
-          }
+          await Promise.all(
+            docs.map((doc) => {
+              return limiter.schedule(
+                async () =>
+                  await processDocumentWithChildren(
+                    doc,
+                    settings.token,
+                    baseProjectUrl,
+                    mavenClient,
+                    knowledgeBaseId
+                  )
+              );
+            })
+          );
         });
       }
     }

--- a/src/inngest/readme.ts
+++ b/src/inngest/readme.ts
@@ -72,19 +72,10 @@ function convertAPIToMarkdown(api: APITypes.APIDefinition) {
   return `${endpoint}\n\n**PATH PARAMS**\n\n${params}\n\n**BODY PARAMS**\n\n${payloads}\n\n**RESPONSES**\n\n${responses}`;
 }
 
-export async function processDocsForCategory(
-  token: string,
-  baseDocUrl: string,
-  categoryId: string,
-  mavenAgi: MavenAGIClient,
-  knowledgeBaseId: string
-) {
-  const docs = await callReadmeApi(`/categories/${categoryId}/docs`, token);
-  console.log('Processing documents in category:', categoryId);
-
-  for (const document of docs) {
-    await processDocumentWithChildren(document, token, baseDocUrl, mavenAgi, knowledgeBaseId);
-  }
+export async function getDocsForCategory(token: string, categorySlug: string) {
+  const docs = await callReadmeApi(`/categories/${categorySlug}/docs`, token);
+  console.log('Processing documents in category:', categorySlug);
+  return docs;
 }
 
 export async function processDocumentWithChildren(

--- a/src/inngest/readme.ts
+++ b/src/inngest/readme.ts
@@ -115,9 +115,9 @@ export async function processDoc(
     return;
   }
   // Categories only return document metadata. For import, we fetch the full doc.
-  const fullReadmeDoc = await callReadmeApi(`/docs/${doc.slug}`, token);
-  const body = fullReadmeDoc.body || fullReadmeDoc.excerpt || '';
-  const apiDoc = convertAPIToMarkdown(fullReadmeDoc.api);
+  const fullDoc = await callReadmeApi(`/docs/${doc.slug}`, token);
+  const body = fullDoc.body || fullDoc.excerpt || '';
+  const apiDoc = convertAPIToMarkdown(fullDoc.api);
   const content = `${body}${apiDoc ? `\n\n${apiDoc}` : ''}`;
 
   if (!content.trim()) {
@@ -126,7 +126,7 @@ export async function processDoc(
   }
 
   await mavenAgi.knowledge.createKnowledgeDocument(knowledgeBaseId, {
-    title: fullReadmeDoc.title,
+    title: fullDoc.title,
     content: content,
     contentType: 'MARKDOWN',
     url: getDocUrlForSlug(baseDocUrl, doc.slug),

--- a/src/inngest/readme.ts
+++ b/src/inngest/readme.ts
@@ -1,127 +1,136 @@
-import {MavenAGIClient} from "mavenagi";
-import {README_API_BASE_URL} from "@inngest/constants";
-import * as APITypes from "@inngest/readmeApi"
-
+import { MavenAGIClient } from 'mavenagi';
+import { README_API_BASE_URL } from '@inngest/constants';
+import * as APITypes from '@inngest/readmeApi';
 
 export async function callReadmeApi(path: string, token: string) {
-    const endpoint = `${README_API_BASE_URL}${path}`;
+  const endpoint = `${README_API_BASE_URL}${path}`;
 
-    const response = await fetch(endpoint, {
-        method: 'GET',
-        headers: {
-            Authorization: `Basic ${token}`,
-            'Content-Type': 'application/json',
-        },
-    });
+  const response = await fetch(endpoint, {
+    method: 'GET',
+    headers: {
+      Authorization: `Basic ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
 
-    if (!response.ok) {
-        throw new Error(
-            `Failed to fetch data from Readme API. Endpoint: ${endpoint}`
-        );
-    }
+  if (!response.ok) {
+    throw new Error(`Failed to fetch data from Readme API. Endpoint: ${endpoint}`);
+  }
 
-    return response.json();
+  return response.json();
 }
 
 export async function getProjectBaseUrl(token: string) {
-    // No path returns the metadata for the specified project token
-    const metadata = await callReadmeApi('', token);
-    return metadata.baseUrl;
+  // No path returns the metadata for the specified project token
+  const metadata = await callReadmeApi('', token);
+  return metadata.baseUrl;
 }
 
 function getDocUrlForSlug(baseUrl: string, slug: string) {
-    // The slug is the path to the document
-    return `${baseUrl}/docs/${slug}`;
+  // The slug is the path to the document
+  return `${baseUrl}/docs/${slug}`;
 }
 
 function getMarkdownForEndpoint(url: string, method: string) {
-    return `**Endpoint**: ${url}\n**Method**: ${method}`;
+  return `**Endpoint**: ${url}\n**Method**: ${method}`;
 }
 
 function getMarkdownForPathParameters(params: APITypes.APIParameter[]) {
-    return params.map((p) => {
-        return `**${p.name}** ${p.type} ${p.required ? "required" : "optional"}\n${p.desc}`;
-    }).join('\n\n');  
-
+  return params
+    .map((p) => {
+      return `**${p.name}** ${p.type} ${p.required ? 'required' : 'optional'}\n${p.desc}`;
+    })
+    .join('\n\n');
 }
 
 function getMarkdownForBodyPayloads(params: APITypes.APIParameter[]) {
-    return params.map((p) => {
-        return `**${p.name}** ${p.type}\n${p.desc}`;
-    }).join('\n\n');
-
+  return params
+    .map((p) => {
+      return `**${p.name}** ${p.type}\n${p.desc}`;
+    })
+    .join('\n\n');
 }
 
 function getMarkdownForResponses(responses: APITypes.APIResults) {
-    return responses?.codes?.sort((a, b) => a.status - b.status).map((r) => {    
-        return `**${r.status}**\n${r.language}\n\`\`\`${r.code}\`\`\``;
-    }).join('\n\n');
+  return responses?.codes
+    ?.sort((a, b) => a.status - b.status)
+    .map((r) => {
+      return `**${r.status}**\n${r.language}\n\`\`\`${r.code}\`\`\``;
+    })
+    .join('\n\n');
 }
 
 function convertAPIToMarkdown(api: APITypes.APIDefinition) {
-    if (!api || !api.url) {
-        return "";
-    }    
-    const endpoint = getMarkdownForEndpoint(api.url, api.method);
-    const params = getMarkdownForPathParameters(api.params.filter((param) => param.in === 'path'));
-    const payloads = getMarkdownForBodyPayloads(api.params.filter((param) => param.in === 'body'));
-    const responses = getMarkdownForResponses(api.results);
+  if (!api || !api.url) {
+    return '';
+  }
+  const endpoint = getMarkdownForEndpoint(api.url, api.method);
+  const params = getMarkdownForPathParameters(api.params.filter((param) => param.in === 'path'));
+  const payloads = getMarkdownForBodyPayloads(api.params.filter((param) => param.in === 'body'));
+  const responses = getMarkdownForResponses(api.results);
 
-    return `${endpoint}\n\n**PATH PARAMS**\n\n${params}\n\n**BODY PARAMS**\n\n${payloads}\n\n**RESPONSES**\n\n${responses}`;
+  return `${endpoint}\n\n**PATH PARAMS**\n\n${params}\n\n**BODY PARAMS**\n\n${payloads}\n\n**RESPONSES**\n\n${responses}`;
 }
 
 export async function processDocsForCategory(
-    token: string,
-    baseDocUrl: string,
-    categoryId: string,
-    mavenAgi: MavenAGIClient,
-    knowledgeBaseId: string
+  token: string,
+  baseDocUrl: string,
+  categoryId: string,
+  mavenAgi: MavenAGIClient,
+  knowledgeBaseId: string
 ) {
-    const docs = await callReadmeApi(`/categories/${categoryId}/docs`, token);
-    console.log('Processing documents in category:', categoryId);
+  const docs = await callReadmeApi(`/categories/${categoryId}/docs`, token);
+  console.log('Processing documents in category:', categoryId);
 
-    for (const document of docs) {
-        await processDocumentWithChildren(document, token, baseDocUrl, mavenAgi, knowledgeBaseId);
-    }
+  for (const document of docs) {
+    await processDocumentWithChildren(document, token, baseDocUrl, mavenAgi, knowledgeBaseId);
+  }
 }
 
 export async function processDocumentWithChildren(
-    document: any,
-    token: string,
-    baseDocUrl: string,
-    mavenAgi: MavenAGIClient,
-    knowledgeBaseId: string
+  document: any,
+  token: string,
+  baseDocUrl: string,
+  mavenAgi: MavenAGIClient,
+  knowledgeBaseId: string
 ) {
-    // Process main document
-    await processDoc(document, token, baseDocUrl, mavenAgi, knowledgeBaseId);
+  // Process main document
+  await processDoc(document, token, baseDocUrl, mavenAgi, knowledgeBaseId);
 
-    // Process child documents
-    for (const childDocument of document.children) {
-        await processDoc(childDocument, token, baseDocUrl, mavenAgi, knowledgeBaseId);
-    }
+  // Process child documents
+  for (const childDocument of document.children) {
+    await processDoc(childDocument, token, baseDocUrl, mavenAgi, knowledgeBaseId);
+  }
 }
 
 export async function processDoc(
-    doc: any,
-    token: string,
-    baseDocUrl: string,
-    mavenAgi: MavenAGIClient,
-    knowledgeBaseId: string
+  doc: any,
+  token: string,
+  baseDocUrl: string,
+  mavenAgi: MavenAGIClient,
+  knowledgeBaseId: string
 ) {
-    // The docs in the category response do not contain all fields. So we must fetch the full doc.
-    const fullReadmeDoc = await callReadmeApi(`/docs/${doc.slug}`, token);
-    if (fullReadmeDoc.body) {
-        console.log('Creating knowledge document for:', fullReadmeDoc.title);
-        const body = fullReadmeDoc.body || "";
-        const apiDoc = convertAPIToMarkdown(fullReadmeDoc.api);
-        const content = `${body}${apiDoc ? `\n\n${apiDoc}`: ""}`;
+  if (doc.hidden) {
+    console.log(`[skipped] Document ${doc.slug} is not published.`);
+    return;
+  }
+  // Categories only return document metadata. For import, we fetch the full doc.
+  const fullReadmeDoc = await callReadmeApi(`/docs/${doc.slug}`, token);
+  const body = fullReadmeDoc.body || fullReadmeDoc.excerpt || '';
+  const apiDoc = convertAPIToMarkdown(fullReadmeDoc.api);
+  const content = `${body}${apiDoc ? `\n\n${apiDoc}` : ''}`;
 
-        await mavenAgi.knowledge.createKnowledgeDocument(knowledgeBaseId, {
-            title: fullReadmeDoc.title,
-            content: content,
-            contentType: 'MARKDOWN',
-            url: getDocUrlForSlug(baseDocUrl, doc.slug),
-            knowledgeDocumentId: { referenceId: doc.slug },
-        });
-    }
+  if (!content.trim()) {
+    console.log(`[skipped] No content in document ${doc.slug}.`);
+    return;
+  }
+
+  await mavenAgi.knowledge.createKnowledgeDocument(knowledgeBaseId, {
+    title: fullReadmeDoc.title,
+    content: content,
+    contentType: 'MARKDOWN',
+    url: getDocUrlForSlug(baseDocUrl, doc.slug),
+    knowledgeDocumentId: { referenceId: doc.slug },
+  });
+  console.log(`[created ] Knowledge document for ${doc.slug}`);
 }

--- a/src/inngest/readme.ts
+++ b/src/inngest/readme.ts
@@ -78,7 +78,7 @@ export async function getDocsForCategory(token: string, categorySlug: string) {
   return docs;
 }
 
-export async function processDocumentWithChildren(
+export async function processDocument(
   document: any,
   token: string,
   baseDocUrl: string,
@@ -88,13 +88,13 @@ export async function processDocumentWithChildren(
   // Process main document
   await processDoc(document, token, baseDocUrl, mavenAgi, knowledgeBaseId);
 
-  // Process child documents
+  // Process child documents, recursively.
   for (const childDocument of document.children) {
-    await processDoc(childDocument, token, baseDocUrl, mavenAgi, knowledgeBaseId);
+    await processDocument(childDocument, token, baseDocUrl, mavenAgi, knowledgeBaseId);
   }
 }
 
-export async function processDoc(
+async function processDoc(
   doc: any,
   token: string,
   baseDocUrl: string,


### PR DESCRIPTION
A number of fixes for CheckHQ:
1. Skip documents marked as `hidden`
2. Preserve those documents that have API definition content even if they have no Markdown `body`
3. Handle arbitrarily nested doc structures (we assumed a single level of doc children)
4. Add `Bottleneck` to control our update rate.
5. Apply our template's `Prettier` settings.